### PR TITLE
Compatibility fixes

### DIFF
--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -16,7 +16,7 @@ error() {
 parse_domains() {
     # For each configuration file in /etc/nginx/conf.d/*.conf*
     for conf_file in /etc/nginx/conf.d/*.conf*; do
-        sed -n -e 's&^\s*ssl_certificate_key\s*\/etc/letsencrypt/live/\(.*\)/privkey.pem;&\1&p' $conf_file | xargs echo | tr ' ' ','
+        sed -n -e 's&^\s*ssl_certificate_key\s*\/etc/letsencrypt/live/\(.*\)/privkey.pem;&\1&p' $conf_file | xargs echo
     done
 }
 

--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -60,6 +60,6 @@ auto_enable_configs() {
 get_certificate() {
     echo "Getting certificate for domain $1 on behalf of user $2"
     certbot certonly --agree-tos --keep -n --text --email $2 --server \
-        https://acme-v02.api.letsencrypt.org/directory -d \*.$1 -d $1 --http-01-port 1337 \
+        https://acme-v02.api.letsencrypt.org/directory -d $1 --http-01-port 1337 \
         --standalone --standalone-supported-challenges http-01 --debug
 }


### PR DESCRIPTION
Two changes that were needed to make this project running:

1. Fix the loop when iterating over domains. They need to be separated by space, not coma. Otherwise, this requests one certificate with all domain names glued together instead of a few individual certificates.

2. Remove the wildcard before the domain name. That is no longer supported with HTTP challenge.