### PR TITLE
set certbot as default server

### DIFF
--- a/nginx_conf.d/certbot.conf
+++ b/nginx_conf.d/certbot.conf
@@ -1,6 +1,6 @@
 server {
     # Listen on plain old HTTP
-    listen 80;
+    listen 80 default_server;
 
     # Pass this particular URL off to certbot, to authenticate HTTPS certificates
     location '/.well-known/acme-challenge' {


### PR DESCRIPTION
Hi there,
that's a really cool tool. I'm using it as a reverse proxy for all kind of testsystems (distinguished by the public name). I've had the problem, that there are some systems, which have to support port 80. In this case, it could happen that nginx did not select the correct server configuration for the acme challenge. This was solved by setting the "default_server" option for the unnamed server configuration. Please check if you would like to merge this change.