### PR TITLE
Update screen to use bash shell and adapt parse_keyfile output to rem…

### DIFF
--- a/src/scripts/entrypoint.sh
+++ b/src/scripts/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # When we get killed, kill all our children
 trap "exit" INT TERM

--- a/src/scripts/run_certbot.sh
+++ b/src/scripts/run_certbot.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Source in util.sh so we can have our nice tools
 . $(cd $(dirname $0); pwd)/util.sh

--- a/src/scripts/util.sh
+++ b/src/scripts/util.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Helper function to output error messages to STDERR, with red text
 error() {
@@ -29,8 +29,9 @@ parse_keyfiles() {
 # keyfiles), return 1 otherwise
 keyfiles_exist() {
     for keyfile in $(parse_keyfiles $1); do
-        if [ ! -f $keyfile ]; then
-            echo "Couldn't find keyfile $keyfile for $1"
+	    currentfile=${keyfile//$'\r'/}
+        if [ ! -f $currentfile ]; then
+            echo "Couldn't find keyfile $currentfile for $1"
             return 1
         fi
     done


### PR DESCRIPTION
…ove starting $ character and trailing carriage return character : fixes certificate not found error

Hi staticfloat, when trying to use your docker-nginx-certbot, I faced an issue related to the return value of the sed command in keyfile_exists method --> it's due to the fact the script is executed by bash shell rather than sh shell. I tried to execute the code with both bash shell and sh shell and it happens that the returned value differ:
* in case of sh shell, we get the right value
* in case of bash shell, we get the right value enclosed in $ and /r signs.

 I did a fix to correct this, let me know what you think