### PR TITLE
Avoid extracting comments when parsing domain names

### DIFF
--- a/src/scripts/util.sh
+++ b/src/scripts/util.sh
@@ -16,7 +16,7 @@ error() {
 parse_domains() {
     # For each configuration file in /etc/nginx/conf.d/*.conf*
     for conf_file in /etc/nginx/conf.d/*.conf*; do
-        sed -n -e 's&^\s*ssl_certificate_key\s*\/etc/letsencrypt/live/\(.*\)/privkey.pem;&\1&p' $conf_file | xargs echo
+        sed -n -r -e 's&^\s*ssl_certificate_key\s*\/etc/letsencrypt/live/(.*)/privkey.pem;\s*(#.*)?$&\1&p' $conf_file | xargs echo
     done
 }
 


### PR DESCRIPTION
When moving from my old nginx config, I had comments of the following form in my config file.

`ssl_certificate_key /etc/letsencrypt/live/my_domain.com/privkey.pem; # hello world`

The current parsing script extracts `hello world` as a domain.

```
+ echo 'running certbot ... https://acme-staging-v02.api.letsencrypt.org/directory hello my@email.com'
running certbot ... https://acme-staging-v02.api.letsencrypt.org/directory hello my@email.com
+ certbot certonly --agree-tos --keep -n --text --email my@email.com --server https://acme-staging-v02.api.letsencrypt.org/directory -d hello --http-01-port 1337 --standalone --preferred-challenges http-01 --debug
```

(note the `hello` as the domain name. One also appears for `#` and `world`)

I've solved this by ensuring anything following the semicolon, if it includes a #, is caught in the sed parsing.