### PR TITLE
Stop container if nginx stops

### DIFF
--- a/src/scripts/entrypoint.sh
+++ b/src/scripts/entrypoint.sh
@@ -42,6 +42,6 @@ while [ true ]; do
     # If nginx quit for whatever reason then stop the container.
     # Leave the restart decision to the container orchestration.
     if ! jobs | grep --quiet nginx ; then
-      exit 1
+        exit 1
     fi
 done

--- a/src/scripts/entrypoint.sh
+++ b/src/scripts/entrypoint.sh
@@ -35,6 +35,13 @@ while [ true ]; do
     sleep 604810 &
     SLEEP_PID=$!
 
-    # Wait on sleep so that when we get ctrl-c'ed it kills everything due to our trap
-    wait "$SLEEP_PID"
+    # Wait for 1 week sleep or nginx
+    wait -n $SLEEP_PID $NGINX_PID
+
+    # Make sure we do not run container empty (without nginx process).
+    # If nginx quit for whatever reason then stop the container.
+    # Leave the restart decision to the container orchestration.
+    if ! jobs | grep --quiet nginx ; then
+      exit 1
+    fi
 done


### PR DESCRIPTION
I had a case where nginx container depend on other services.
nginx failed if those service didn't go up soon enough, but wasn't restarted properly.
From dockerd perspective the container was still up even though there was no nginx process running.

This fixes it by waiting till sleep or nginx exits.