### PR TITLE
envsubst need double $$ for docker-compose

### DIFF
--- a/src/scripts/util.sh
+++ b/src/scripts/util.sh
@@ -103,7 +103,7 @@ template_user_configs() {
     TARGET_DIR="${2-/etc/nginx/conf.d}"
 
     # envsubst needs dollar signs in front of all variable names
-    DENV=$(echo ${ENVSUBST_VARS} | sed -E 's/\$*([^ ]+)/\$\1/g')
+    DENV=$(echo ${ENVSUBST_VARS} | sed -E 's/\$*([^ ]+)/\$$\1/g')
 
     echo "templating scripts from ${SOURCE_DIR} to ${TARGET_DIR}"
     echo "Substituting variables ${DENV}"


### PR DESCRIPTION
## The problem
If you try to start the server with `docker-compose up` you get this error:
```
frontend_1  | Substituting variables FQDN
frontend_1  | envsubst: error while reading "standard input": Is a directory
```
## The fix
Docker-compose need doble $$ for variable-substitution, [see doc here](https://docs.docker.com/compose/compose-file/#variable-substitution)
