### PR TITLE
(doc) precision regarding ENVSUBST_VARS

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ services:
             - 443:443/tcp
         environment:
             CERTBOT_EMAIL: owner@company.com
+            # variable names are space-separated
             ENVSUBST_VARS: FQDN
             FQDN: server.company.com
         volumes:


### PR DESCRIPTION
Maybe that's the default way to build lists, however I didn't know about it before looking at the source of your utils.