### PR TITLE
 forward request/error logs to docker log

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -28,5 +28,9 @@ RUN mkdir -p /scripts/startup
 RUN rm -f /etc/nginx/conf.d/*
 COPY nginx_conf.d/ /etc/nginx/conf.d/
 
+# forward request and error logs to docker log collector
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+	&& ln -sf /dev/stderr /var/log/nginx/error.log
+
 ENTRYPOINT []
 CMD ["/bin/bash", "/scripts/entrypoint.sh"]


### PR DESCRIPTION
Minor change to add the output of Nginx logs to the docker logs. That way it is easier to debug problems and analyze requests.

Ref:
- https://github.com/nginxinc/docker-nginx/blob/8921999083def7ba43a06fabd5f80e4406651353/mainline/jessie/Dockerfile#L21-L23
- https://docs.docker.com/config/containers/logging/