### PR TITLE
Update README to indicate port 80 caeveat.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ volumes:
 
 Launch that docker-compose file, and you're good to go; `certbot` will automatically request an SSL certificate for any `nginx` sites that look for SSL certificates in `/etc/letsencrypt/live`, and will automatically renew them over time.
 
+Note: using a `server` block that listens on port 80 may cause issues with renewal. This container will already handle forwarding to port 443, so they are unnecessary.
+
 ## Templating
 
 You may wish to template your configurations, e.g. passing in a hostname so as to be able to run multiple identical copies of this container; one per website.  The docker container will use [`envsubst`](https://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html) to template all mounted user configs with a user-provided list of environment variables.  Example:


### PR DESCRIPTION
I found that if I had 

```
server {
      listen 80;
      server_name my_website.com;
      return 301 https://$server_name$request_uri;
}
```

`.well-known/acme-certs` would 404, as it would attempt to redirect to my domain and fail, since the `server_name` block is more specific. 

The README now documents this caveat, since it is already handled by the config. 

I would open an issue, but they are disabled, so I figured this is the next best thing. Sorry if this is a bit out of form.