### PR TITLE
Bump python to 3.7

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -8,10 +8,10 @@ EXPOSE 443
 # Do this apt/pip stuff all in one RUN command to avoid creating large
 # intermediate layers on non-squashable docker installs
 RUN apt update && \
-    apt install -y python python-dev libffi6 libffi-dev libssl-dev curl build-essential procps && \
-    curl -L 'https://bootstrap.pypa.io/get-pip.py' | python && \
+    apt install -y python3 python3-dev libffi6 libffi-dev libssl-dev curl build-essential procps && \
+    curl -L 'https://bootstrap.pypa.io/get-pip.py' | python3 && \
     pip install -U cffi certbot && \
-    apt remove --purge -y python-dev build-essential libffi-dev libssl-dev curl && \
+    apt remove --purge -y python3-dev build-essential libffi-dev libssl-dev curl && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Hi,

I am maintaining https://github.com/lnobach/nctalk-backend-cloud-config and I liked nginx-certbot, so I used it in the docker-compose.

Today I stumbled over the following error while creating an instance:
```
proxy_1          | running certbot ... https://acme-v02.api.letsencrypt.org/directory [...] [...]
proxy_1          | Traceback (most recent call last):
proxy_1          |   File "/usr/local/bin/certbot", line 5, in <module>
proxy_1          |     from certbot.main import main
proxy_1          |   File "/usr/local/lib/python2.7/dist-packages/certbot/main.py", line 2, in <module>
proxy_1          |     from certbot._internal import main as internal_main
proxy_1          |   File "/usr/local/lib/python2.7/dist-packages/certbot/_internal/main.py", line 21, in <module>
proxy_1          |     from certbot._internal import cert_manager
proxy_1          |   File "/usr/local/lib/python2.7/dist-packages/certbot/_internal/cert_manager.py", line 16, in <module>
proxy_1          |     from certbot._internal import storage
proxy_1          |   File "/usr/local/lib/python2.7/dist-packages/certbot/_internal/storage.py", line 79, in <module>
proxy_1          |     def add_time_interval(base_time, interval, textparser=parsedatetime.Calendar()):
proxy_1          |   File "/usr/local/lib/python2.7/dist-packages/parsedatetime/__init__.py", line 270, in __init__
proxy_1          |     self.ptc = Constants()
proxy_1          |   File "/usr/local/lib/python2.7/dist-packages/parsedatetime/__init__.py", line 2381, in __init__
proxy_1          |     self.locale = get_icu(self.localeID)
proxy_1          |   File "/usr/local/lib/python2.7/dist-packages/parsedatetime/pdt_locales/icu.py", line 56, in get_icu
proxy_1          |     result['icu'] = icu = pyicu.Locale(locale)
proxy_1          | AttributeError: 'module' object has no attribute 'Locale'
proxy_1          | + error 'Cerbot failed for [...]. Check the logs for details.'

```

Got it fixed with switching to Python 3.7 (Python 2 is deprecated). The proposed change works fine on my infrastructure, but please confirm that it works for you as well.

I have a Docker Hub autobuild available: lnobach/nginx-certbot