### PR TITLE
added extra domains supported.

### DIFF
--- a/example/certbot_extra_domains/README.md
+++ b/example/certbot_extra_domains/README.md
@@ -1,0 +1,2 @@
+1. put your letsencript primary key domain name as the filename.
+2. list extra domain names each line in the file.

--- a/example/certbot_extra_domains/example.com
+++ b/example/certbot_extra_domains/example.com
@@ -1,0 +1,3 @@
+www.example.com
+sub1.example.com
+sub2.example.com

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -11,4 +11,5 @@ services:
       - "443:443"
     volumes:
       - ./conf.d:/etc/nginx/user.conf.d:ro
+      - ./certbot_extra_domains:/etc/nginx/certbot/extra_domains:ro
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,10 @@
+
+$(warning $(shell IMAGE_NAME=$(IMAGE_NAME) printenv | grep IMAGE_NAME))
+ifndef IMAGE_NAME
+	#$(warning IMAGE_NAME is not set)
+	IMAGE_NAME=nginx-certbot
+endif
+
 # If we have `--squash` support, then use it!
 ifneq ($(shell docker build --help 2>/dev/null | grep squash),)
 DOCKER_BUILD = docker build --squash
@@ -8,8 +15,8 @@ endif
 all: build
 
 build: Makefile Dockerfile
-	$(DOCKER_BUILD) -t staticfloat/nginx-certbot .
-	@echo "Done!  Use docker run staticfloat/nginx-certbot to run"
+	$(DOCKER_BUILD) -t $(IMAGE_NAME) .
+	@echo "Done!  Use docker run $(IMAGE_NAME) to run"
 
 push:
-	docker push staticfloat/nginx-certbot
+	docker push $(IMAGE_NAME)

--- a/src/scripts/run_certbot.sh
+++ b/src/scripts/run_certbot.sh
@@ -14,10 +14,12 @@ set -x
 # Loop over every domain we can find
 for domain in $(parse_domains); do
     if is_renewal_required $domain; then
+        extra_domains=$(parse_extra_domains $domain)
+        renewal_domains="$domain $extra_domains"
         # Renewal required for this doman.
         # Last one happened over a week ago (or never)
-        if ! get_certificate $domain $CERTBOT_EMAIL; then
-            error "Cerbot failed for $domain. Check the logs for details."
+        if ! get_certificate "$renewal_domains" $CERTBOT_EMAIL; then
+            error "Cerbot failed for $renewal_domain. Check the logs for details."
             exit_code=1
         fi
     else


### PR DESCRIPTION
1. nginx server_name may require multi alias domains
2. the current script only supports one domain in each vhost block. 
3. this pull request added a config file for the primary domain that parsed from letsencript primary key folder name, which will help the certbot script being able to make a certificate for multi-domains.
