### PR TITLE
Allow expanding certs via extra_domains_conf

### DIFF
--- a/src/scripts/util.sh
+++ b/src/scripts/util.sh
@@ -81,7 +81,7 @@ get_certificate() {
     opt_domains=$(for i in $1; do printf -- "-d $i "; done;)
 
     echo "running certbot ... $letsencrypt_url $1 $2"
-    certbot certonly --agree-tos --keep -n --text --email $2 --server \
+    certbot certonly --expand --agree-tos --keep -n --text --email $2 --server \
         $letsencrypt_url $opt_domains --http-01-port 1337 \
         --standalone --preferred-challenges http-01 --debug
 }


### PR DESCRIPTION
Without this change, you get errors from certbot asking (interactively) if you want to replace/expand the certificate 

Manually fixing this involve deleting all the files for the domain in question and rerunning which is way more destructive