### PR TITLE
Correct volume path for extra domains

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -11,5 +11,5 @@ services:
       - "443:443"
     volumes:
       - ./conf.d:/etc/nginx/user.conf.d:ro
-      - ./certbot_extra_domains:/etc/nginx/certbot/extra_domains:ro
+      - ./certbot_extra_domains:/etc/certbot/extra_domains:ro
 


### PR DESCRIPTION
Edit the container path for the `certbot_extra_domains` volume, to match the path in `scripts/utils.sh`.