### PR TITLE
Update parse_domains parsing

### DIFF
--- a/src/scripts/util.sh
+++ b/src/scripts/util.sh
@@ -21,10 +21,7 @@ parse_extra_domains() {
 # (no wildcards) and each keyfile will be stored at the default location of
 # /etc/letsencrypt/live/<primary_domain_name>/privkey.pem
 parse_domains() {
-    # For each configuration file in /etc/nginx/conf.d/*.conf*
-    for conf_file in /etc/nginx/conf.d/*.conf*; do
-        sed -n -r -e 's&^\s*ssl_certificate_key\s*\/etc/letsencrypt/live/(.*)/privkey.pem;\s*(#.*)?$&\1&p' $conf_file | xargs echo
-    done
+    sed -n -r -e 's&^\s*ssl_certificate_key\s*\/etc/letsencrypt/live/(.*)/privkey.pem;\s*(#.*)?$&\1&p' /etc/nginx/conf.d/*.conf* | sort | uniq | xargs echo
 }
 
 # Given a config file path, spit out all the ssl_certificate_key file paths


### PR DESCRIPTION
This setup handles multiple vhosts with the same domain being processed multiple times during the "run_certbot" flow by finding all of them, sorting them, and taking only unique values for processing.

In my setup with more than 20 vhosts that have subdomains of a single root domain (and maintained via extra_domains configuration, this significantly limits the number of API hits to ACME, and prevents getting blocked when misconfigured